### PR TITLE
fix(deploy): verify tmdk.json and add unit test

### DIFF
--- a/src/libs/tmdk/package.json
+++ b/src/libs/tmdk/package.json
@@ -7,8 +7,8 @@
     "tmdk": "./build/cli.js"
   },
   "scripts": {
-    "test": "./node_modules/.bin/jest",
-    "integ-test": "./node_modules/.bin/jest -c jest.config.integration.js",
+    "test": "./node_modules/.bin/jest --silent",
+    "integ-test": "./node_modules/.bin/jest --silent -c jest.config.integration.js",
     "build": "./node_modules/typescript/bin/tsc && npm run package",
     "build-global": "npx tsc && npm run package && npm install -g",
     "package": "node build.js",

--- a/src/libs/tmdk/src/commands/deploy.ts
+++ b/src/libs/tmdk/src/commands/deploy.ts
@@ -70,9 +70,14 @@ export const handler = async (argv: Arguments<Options>) => {
   // console.log(result);
 
   // read tmdk json file
-  var tmdk_config_buffer = fs.readFileSync(`${dir}/tmdk.json`, 'utf-8'); // TODO encodings
-  var tmdk_config_str = `${tmdk_config_buffer}`
-  var tmdk_config: any = JSON.parse(tmdk_config_str)
+  try {
+    var tmdk_config_buffer = fs.readFileSync(`${dir}/tmdk.json`, 'utf-8'); // TODO encodings
+    var tmdk_config_str = `${tmdk_config_buffer}`
+    var tmdk_config: any = JSON.parse(tmdk_config_str)
+  } catch (e) {
+    console.log(`Error: could not read '${dir}'/tmdk.json.`)
+    process.exit(1);
+  }
   console.log("========= tmdk.json =========")
   console.log(tmdk_config);
 

--- a/src/libs/tmdk/tests/deploy.test.ts
+++ b/src/libs/tmdk/tests/deploy.test.ts
@@ -28,7 +28,7 @@ jest.mock("../src/lib/aws-clients", () => {
       }
     }),
   }
-})
+});
 
 describe('testing deploy', () => {
   beforeEach(mockExit.mockClear);
@@ -43,5 +43,5 @@ describe('testing deploy', () => {
     } as Arguments<Options>;
     await expect(handler(argv2)).rejects.toThrow(Error);
     expect(mockExit).toHaveBeenCalledWith(1);
-  }, 120000);
+  });
 });

--- a/src/libs/tmdk/tests/deploy.test.ts
+++ b/src/libs/tmdk/tests/deploy.test.ts
@@ -2,53 +2,46 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { handler, Options } from '../src/commands/deploy';
-import {Arguments} from "yargs";
+import { Arguments } from "yargs";
+import { ResourceNotFoundException } from "@aws-sdk/client-iottwinmaker";
+import { GetWorkspaceCommandInput } from "@aws-sdk/client-iottwinmaker/dist-types/commands/GetWorkspaceCommand";
 
-import {
-  ConflictException,
-  CreateComponentTypeRequest,
-  ResourceNotFoundException, ValidationException,
-  GetWorkspaceCommand, IoTTwinMakerClient, GetWorkspaceCommandOutput
-} from "@aws-sdk/client-iottwinmaker";
+const mockExit = jest.spyOn(process, 'exit').mockImplementation((number) => { throw new Error('process.exit: ' + number); });
 
-const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => { return undefined as never });
+jest.mock("../src/lib/aws-clients", () => {
+  return {
+    initDefaultAwsClients: () => {},
 
-import {GetWorkspaceCommandInput} from "@aws-sdk/client-iottwinmaker/dist-types/commands/GetWorkspaceCommand";
+    getDefaultAwsClients: jest.fn().mockImplementation(() => {
+      return {
+        tm: {
+          getWorkspace: (input: GetWorkspaceCommandInput) => {
+            console.log(`intercepted ws: ${input.workspaceId}`);
 
-// TODO uncomment to enable mocking behavior
-// jest.mock("../src/lib/aws-clients", () => {
-//   return {
-//     initDefaultAwsClients: () => {},
-//
-//     getDefaultAwsClients: jest.fn().mockImplementation(() => {
-//       return {
-//         tm: {
-//           getWorkspace: (input: GetWorkspaceCommandInput) => {
-//             console.log(`intercepted ws: ${input.workspaceId}`);
-//
-//             if (`${input.workspaceId}` == 'non-existent') {
-//               throw new ResourceNotFoundException({"$metadata": {}})
-//             } else if (`${input.workspaceId}` == 'error') {
-//               throw new Error("mock error");
-//             } else {
-//               return {};
-//             }
-//           }
-//         }
-//       }
-//     }),
-//   }
-// })
+            if (`${input.workspaceId}` == 'non-existent') {
+              throw new ResourceNotFoundException({"$metadata": {}, "message": ""})
+            } else {
+              return {};
+            }
+          }
+        }
+      }
+    }),
+  }
+})
 
 describe('testing deploy', () => {
-  test('test01', () => {
+  beforeEach(mockExit.mockClear);
+
+  test('deploy_givenNoTMDKProject_expectError', async () => {
     var argv2 = {
-      _: [ 'init' ],
+      _: [ 'deploy' ],
       '$0': 'tmdk_local',
       region: "us-east-1",
-      "workspace-id": "SyncC",
-      dir: "/tmp/integ-test-init2"
+      "workspace-id": "irrelevant",
+      dir: "/tmp/deploy-unit-tests/i-do-not-exist"
     } as Arguments<Options>;
-    return handler(argv2).then(result => expect(result).toBe(0));
+    await expect(handler(argv2)).rejects.toThrow(Error);
+    expect(mockExit).toHaveBeenCalledWith(1);
   }, 120000);
 });

--- a/src/libs/tmdk/tests/test-utils.ts
+++ b/src/libs/tmdk/tests/test-utils.ts
@@ -1,3 +1,0 @@
-export function createTmdkDirectory(): {
-
-}

--- a/src/libs/tmdk/tests/test-utils.ts
+++ b/src/libs/tmdk/tests/test-utils.ts
@@ -1,0 +1,3 @@
+export function createTmdkDirectory(): {
+
+}


### PR DESCRIPTION
When tmdk.json is read for deploy, catch any exceptions while trying to read or parse. Add a simple unit test to verify this behavior. Also make jest tests silent for package.